### PR TITLE
[prefs] update to reflect status of recent darktable master

### DIFF
--- a/content/preferences-settings/cpu-gpu-memory.md
+++ b/content/preferences-settings/cpu-gpu-memory.md
@@ -17,13 +17,13 @@ enable disk backend for full preview cache
 : If enabled, darktable writes full preview images to disk (`.cache/darktable/`) when evicted from the memory cache. Note that this can take a lot of memory (several gigabytes for 20k images) and darktable will never delete cached images. It's safe to delete these manually if you want. Enabling this option will greatly improve _lighttable_ performance when zooming an image in full preview mode (default off).
 
 number of background threads
-: This controls how many parallel threads are used to create thumbnails during import. On 32bit systems it is strongly recommended to set this to 1. Needs a restart if changed (default 2).
+: This controls how many parallel threads are used to create thumbnails during import. Needs a restart if changed (default 2).
 
 host memory limit (in MB) for tiling
-: In order to manage large images on systems with limited memory darktable does tile-wise processing. This variable controls the maximum amount of memory (in MB) a module may use during image processing. Lower values will force memory hungry modules to process an image with increasing number of tiles. Setting this to 0 will omit any limits. Values below 500 will be treated as 500. On a 32bit system you should set this to 500. Needs a restart if changed (default 1500).
+: In order to manage large images on systems with limited memory darktable does tile-wise processing. This variable controls the maximum amount of memory (in MB) a module may use during image processing. Lower values will force memory hungry modules to process an image with increasing number of tiles. Setting this to 0 will omit any limits. Values below 500 will be treated as 500. Needs a restart if changed (default 1500).
 
 minimum amount of memory (in MB) for a single buffer in tiling
-: If set to a positive, non-zero value, this variable defines the minimum amount of memory (in MB) that darktable should take for a single tile. On a 32bit system you should set this to 8. 64bit systems can cope with higher values. Needs a restart if changed (default 16).
+: If set to a positive, non-zero value, this variable defines the minimum amount of memory (in MB) that darktable should take for a single tile. Needs a restart if changed (default 16).
 
 activate [OpenCL](../special-topics/opencl/_index.md) support
 : _darktable_ can use your GPU to significantly speed up processing. The OpenCL interface requires suitable hardware and matching OpenCL drivers on your system. If one of those is not found the option is greyed out. Can be switched on and off at any time and takes immediate effect (default on).

--- a/content/preferences-settings/darkroom.md
+++ b/content/preferences-settings/darkroom.md
@@ -22,8 +22,14 @@ pattern for the image information line
 position of the image information line
 : Control the darkroom panel in which the [image information line](../module-reference/utility-modules/darkroom/image-info-line.md) is displayed. Choose between “top left” “top right” “top center” “bottom” and “hidden” (default "bottom").
 
-show search module text entry
-: Controls how [processing modules](../module-reference/processing-modules) can be searched and grouped. You can choose between “groups icons” “search entry” “both” (default "both"). See [searching for and grouping modules](../darkroom/interacting-with-modules/search-and-group.md). (need a restart)
+show module groups and/or search text entry
+: Controls how [processing modules](../module-reference/processing-modules) can be searched and grouped. You can choose between “show search text” “show groups” and “show both” (default "show both"). See [searching for and grouping modules](../darkroom/interacting-with-modules/search-and-group.md). (need a restart)
+
+sort buit-in presets first
+: Controls sorting of processing modules presets. If this option is enabled, the built-in presets are shown first in presets menu. If the option is disabled, user's presets are shown first (default on).
+
+hide built-in presets
+: Controls presence of built-in presets in processing module presets menu. If enabled, only user's presets will be shown in presesets menu (default off).
 
 expand a single darkroom module at a time
 : Controls how [processing modules](../module-reference/processing-modules) are expanded. If this option is enabled, expanding a module by clicking collapses any currently expanded module. If you want to expand a module without collapsing the others you can do so with `Shift+click`. Disabling this option inverts the meaning of `click` and `Shift+click` (default on).
@@ -49,3 +55,29 @@ demosaicing for zoomed out darkroom mode
 
 reduce resolution of preview image
 : Reduce the resolution of the [navigation preview](../module-reference/utility-modules/darkroom/navigation.md) image (choose from "original", "1/2", "1/3" or "1/4" size). This may improve the speed of the rendering but take care as it can also hinder accurate masking (default "original").
+
+white balace slider colors
+: Controls appearance of [white balance](../module-reference/processing-modules/white-balance.md) sliders.
+: _no color_ - background of the sliders is not colored at all.
+: _illuminant color_ - slider colors represent the color of the light source, i.e. the color you are adjusting to in order to achieve neutral white
+: _efect emulation_ - slider colors represent the effect the adjustment would have had on the scene. This is how most other raw processors show temperature/tint sliders colors.
+: (default _no color_)
+
+colorbalance slider block layout
+: Controls appearance of [color balance](../module-reference/processing-modules/color-balance.md) shadows/mid-tones/highlights sections ui
+: _list_ - all sliders are shown in one long list (with headers)
+: _tabs_ - use tabs to switch between the blocks of sliders
+: _columns_ - the blocks of sliders are shown next to each other (in narrow columns)
+: (default _list_)
+
+show right-side buttons in darkroom module headers
+: Controls presence of processing module header button 
+: _always_ - always show all buttons
+: _active_ - only show the buttons when the mouse is over the module
+: _dim_ - buttons are dimmed when mouse is away
+: _auto_ - hide the buttons when the panel is narrow
+: _fade_ - fade out all buttons when panel narrows
+: _fit_ - hide all the buttons if the module name doesn't fit
+: _smooth_ - fade out all buttons in one header simultaneously
+: _glide_ - gradually hide individual buttons as needed
+: (default _always_)

--- a/content/preferences-settings/other-views.md
+++ b/content/preferences-settings/other-views.md
@@ -9,9 +9,6 @@ The following options control functionality in the [map](../map/_index.md) and [
 
 ### map / geolocalisation
 
-only draw images on map that are currently collected and filtered
-: Use the current filter settings to select the geotagged images drawn in the map view. This limits the images drawn to those currently shown in the filmstrip and thus reduces the time needed (default off).
-
 maximum number of images drawn on map
 : The maximum number of geotagged images drawn on the map. Increasing this number can slow down the drawing of the map. Needs a restart if changed (default 100).
 

--- a/content/preferences-settings/overview.md
+++ b/content/preferences-settings/overview.md
@@ -6,3 +6,5 @@ draft: false
 ---
 
 darktable comes with a number of user-configurable preferences. These can be adjusted in the preferences dialog, which can be reached by clicking the gear icon on the right of the [top panel](../overview/user-interface/top-panel.md).
+
+Non-default setting values are highlighted for easy spotting. Double click on setting label resets setting to default.

--- a/content/preferences-settings/presets.md
+++ b/content/preferences-settings/presets.md
@@ -9,7 +9,7 @@ This menu gives you an overview of the [presets](../darkroom/interacting-with-mo
 
 Pre-defined presets (those that are included by default within darktable) are shown with a lock symbol. Their auto-apply properties cannot be changed.
 
-Double clicking on a user-defined preset will open a menu. This allows the chosen preset to be edited or saved to an external `.dtpreset` file. 
+Selecting user-defined preset and pressing `Enter` key or Double clicking on it will open an edit dialog. This allows the chosen preset to be edited, saved to an external `.dtpreset` file or deleted from list of presets. Selecting user-defined preset and pressing `Delete` key will allow user to delete preset.
 
 See the [presets](../darkroom/interacting-with-modules/presets.md) section for more information.
 

--- a/content/preferences-settings/processing.md
+++ b/content/preferences-settings/processing.md
@@ -35,4 +35,4 @@ auto-apply per camera basecurve presets
 : Use the per-camera basecurve by default instead of the generic manufacturer one if there is one available. This should only be used in conjunction with the _display referred_ workflow defined above (default off).
 
 auto-apply sharpen
-: Auto-apply the sharpen module to new images by default. This option is not recommended on cameras without a low-pass filter. The default is to not add any sharpening automatically as most recent cameras have no low-pass filter (requires a restart).
+: Auto-apply the sharpen module to new images by default. This option is not recommended on cameras without a low-pass filter. (default on, requires a restart).

--- a/content/preferences-settings/storage.md
+++ b/content/preferences-settings/storage.md
@@ -19,7 +19,7 @@ create database snapshot
 : Specifies how often darktable should create database snapshots. Options are "never", "once a month", "once a week", "once a day" and "on close" (default "once a week")
 
 how many snapshots to keep
-: Number of snapshots to keep after creating a new snapshot, not counting database backups taken when moving between darktable versions. Enter "-1" to store an unlimited number of snapshots. (default 5)
+: Number of snapshots to keep after creating a new snapshot, not counting database backups taken when moving between darktable versions. Enter "-1" to store an unlimited number of snapshots. (default 10)
 
 ### xmp
 


### PR DESCRIPTION
Couple updates in preferences window to match current master

Couple notes:
1. darktable seems to no longer support 32-bit systems, removed reference to bitness of systems.
2. map somewhere along the line lost the filtering of images, so the option was removed from manual
3. all changes reflect darktable _current master_ as of 03.10.2020 12:50 CEST