### PR TITLE
fix broken links

### DIFF
--- a/content/overview/sidecar-files/local-copies.md
+++ b/content/overview/sidecar-files/local-copies.md
@@ -10,7 +10,7 @@ Many users have huge image collections stored on extra hard drives in their desk
 
 It is a common requirement to be able to develop a number of images while travelling using a laptop and then later synchronize them back to the original storage medium. However, copying images manually from the main storage to the laptop and back is cumbersome and prone to errors. The “local copies” feature of darktable has been designed to directly support these use cases. 
 
-You can create local copies of selected images from within the lighttable. Local copies are always used when present, giving continued access to images even if the external storage is no longer connected. At a later point, when your primary storage medium has been reconnected, you can synchronize the XMP sidecar files back to this storage, deleting any local copies. These operations can be found in the [selected images](../../module-reference/utility-modules/lighttable/selected-images.md) module in the lighttable.
+You can create local copies of selected images from within the lighttable. Local copies are always used when present, giving continued access to images even if the external storage is no longer connected. At a later point, when your primary storage medium has been reconnected, you can synchronize the XMP sidecar files back to this storage, deleting any local copies. These operations can be found in the [selected images](../../module-reference/utility-modules/lighttable/selected-image.md) module in the lighttable.
 
 For safety reasons, if local copies exist and the external storage is available, the local XMP sidecars are automatically synchronized at start up.
 

--- a/content/preferences-settings/lighttable.md
+++ b/content/preferences-settings/lighttable.md
@@ -20,7 +20,7 @@ sort film rolls by
 : Sort film rolls by either the "folder" (path) or the film roll "id" in the [collect images](../module-reference/utility-modules/shared/collect-images.md) module. Select "id" to sort film rolls by the date they were first imported into darktable. (default "id").
 
 sort collection recent to older
-: Within the [collect images](../module-references/utility-modules/shared/collect-images.md) module, sort items from recent to older when selecting folders and times/dates (default on).
+: Within the [collect images](../module-reference/utility-modules/shared/collect-images.md) module, sort items from recent to older when selecting folders and times/dates (default on).
 
 high quality thumbnail processing from size
 : If the thumbnails size is greater than this value, it will be processed using the full quality rendering path, which is better but slower (default 720p).


### PR DESCRIPTION
when building PDF, got some errors due to typos in links, so this allows PDF to build cleanly.