### PR TITLE
zoomable-lighttable: pad out content with example use case

### DIFF
--- a/content/lighttable/lighttable-modes/zoomable-lighttable.md
+++ b/content/lighttable/lighttable-modes/zoomable-lighttable.md
@@ -6,6 +6,21 @@ weight: 20
 author: "people"
 ---
 
-Zoomable lighttable mode inherits most of its features from the filemanager mode, with some notable changes.
+Lighttable has a _zoomable_ mode that allows for easy intuitive way to navigate large collections of images. If you are trying to find something quickly in a collection, it allows you to zoom out so that you can see a large number of thumbnails, then you can move the lighttable around. When you recognise something in the thumbnails, you can easily zoom in to check if that is really what you were looking for, and if not, zoom out again and keep looking. An example might be looking for images of a bride at a wedding -- the white dress will standout in the thumbnails, so it will stand out in the thumbnails. You can search for images with the bride, zoom in, rate or tag them for future processing, and keep looking.
 
-Scroll with your mouse wheel to zoom in and out. Move the mouse while pressing the left mouse button to navigate through your collection.
+Apart from the navigation aspects, the _zoomable_ mode works the same as the _filemanager_ mode.
+
+---
+
+**Hint:** you may find that the images are slow to load when zooming quickly through a large collection. One way to speed up the navigation is to generate a cache containing all the thumbnails using the [darktable-generate-cache](../../special-topics/program-invocation/darktable-generate-cache.md) command.
+
+---
+
+# module controls
+
+`Scroll-mouse-wheel`
+: Use the mouse wheel to zoom in and out fro mthe lighttable
+
+`Drag`
+: Hold down the left mouse button to drag the images around on the lighttable to navigate through your collection.
+


### PR DESCRIPTION
flesh out the zoomable lighttable description with a sample use case and a hint about the darktable-generate-cache command.