### PR TITLE
Change where npm install runs.

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,7 +21,7 @@ jobs:
           extended: true
 
       - name: npm Install
-        run: cd themes/hugo-bootstrap-bare/assets/ && npm install
+        run: cd themes/hugo-darktable-docs-theme/assets/ && npm install
 
       - name: Build
         run: hugo


### PR DESCRIPTION
I've added the fork awesome npm package in the hugo-darktable-docs-theme, so we need to run npm install in that theme directory rather than hugo-bootstrap-bare.