### PR TITLE
pixelpipe: use concept of layers to describe processing modules

### DIFF
--- a/content/darkroom/processing-modules-and-pixelpipe/the-anatomy-of-a-module.md
+++ b/content/darkroom/processing-modules-and-pixelpipe/the-anatomy-of-a-module.md
@@ -5,7 +5,9 @@ weight: 10
 draft: false
 ---
 
-The basic element of image processing in darktable is the _module_. In order to process a raw image a number of modules act on the input image in sequence, each performing a different _operation_ on the image data.
+The basic element of image processing in darktable is the _processing module_. In order to process a raw image a number of modules act on the input image in sequence, each performing a different _operation_ on the image data. For those familiar with Adobe Photoshop, the concept of a _processing module_ in darktable is somewhat similar to an _adjustment layer_ in that that are both making an adjustment to an image, and each one is building on top of all the processing steps that came before.
+
+There are also _utility modules_ in darktable, however these are not directly involved in the image processing, and are instead providing a GUI that allows you to manage your images, tag them, export them and so on.
 
 Every processing module executes independently in a similar manner:
 

--- a/content/darkroom/processing-modules-and-pixelpipe/the-anatomy-of-a-module.md
+++ b/content/darkroom/processing-modules-and-pixelpipe/the-anatomy-of-a-module.md
@@ -5,9 +5,9 @@ weight: 10
 draft: false
 ---
 
-The basic element of image processing in darktable is the _processing module_. In order to process a raw image a number of modules act on the input image in sequence, each performing a different _operation_ on the image data. For those familiar with Adobe Photoshop, the concept of a _processing module_ in darktable is somewhat similar to an _adjustment layer_ in that that are both making an adjustment to an image, and each one is building on top of all the processing steps that came before.
+The basic element of image processing in darktable is the [_processing module_](../../module-reference/processing-modules/). In order to process a raw image a number of modules act on the input image in sequence, each performing a different _operation_ on the image data. For those familiar with Adobe Photoshop, the concept of a _processing module_ in darktable is somewhat similar to an _adjustment layer_ in that that are both making an adjustment to an image, and each one is building on top of all the processing steps that came before.
 
-There are also _utility modules_ in darktable, however these are not directly involved in the image processing, and are instead providing a GUI that allows you to manage your images, tag them, export them and so on.
+There are also [_utility modules_](../../module-reference/utility-modules/) in darktable, however these are not directly involved in the image processing, and are instead providing a GUI that allows you to manage your images, tag them, export them and so on.
 
 Every processing module executes independently in a similar manner:
 

--- a/content/darkroom/processing-modules-and-pixelpipe/the-pixelpipe-and-module-order.md
+++ b/content/darkroom/processing-modules-and-pixelpipe/the-pixelpipe-and-module-order.md
@@ -7,7 +7,7 @@ draft: false
 
 The ordered sequence of [processing modules](../../module-reference/processing-modules/_index.md) operating on an input file to generate an output image is known as the "pixelpipe". 
 
-The order of the pixelpipe is represented graphically by the order in which modules are presented in the user interface -- the pixelpipe runs from the bottom to the top of the modules as they appear in the darkroom view (RAW image at the bottom of the pixelpipe and output image at the top). 
+The order of the pixelpipe is represented graphically by the order in which modules are presented in the user interface -- the pixelpipe starts with a RAW image at the bottom of the list, and applies the processing modules one by one, piling up layer upon layer of processing from the bottom up, until it reaches the top of the list, at which point we have a fully processed image.
 
 ---
 

--- a/content/module-reference/overview.md
+++ b/content/module-reference/overview.md
@@ -9,7 +9,7 @@ author: "people"
 The modules in this reference section are broken down into two types:
 
 [processing modules](./processing-modules/_index.md)
-: These modules are used exclusively in the darkroom view, and each performs a layer of pixel processing operations on your image. Together they form the [pixelpipe](../darkroom/processing-modules-and-pixelpipe/the-pixelpipe-and-module-order.md).
+: These modules are used exclusively in the darkroom view, and each performs its set of pixel processing operations on the image before passing the image up to the next modules so it can add its processing on top. Together this set of processing steps performed by each module forms the [pixelpipe](../darkroom/processing-modules-and-pixelpipe/the-pixelpipe-and-module-order.md).
 
 [utility modules](./utility-modules/_index.md)
 : These modules may be used in any darktable view. They are not directly involved in processing the pixels of your image; instead they perform other ancillary functions related to managing the image metadata and tags, editing history, modifying overall pixel pipeline order, snapshots and duplicates, image export and so on.

--- a/content/module-reference/overview.md
+++ b/content/module-reference/overview.md
@@ -9,10 +9,10 @@ author: "people"
 The modules in this reference section are broken down into two types:
 
 [processing modules](./processing-modules/_index.md)
-: These modules are used exclusively in the darkroom view to perform pixel operations on your image. Together they form the [pixelpipe](../darkroom/processing-modules-and-pixelpipe/the-pixelpipe-and-module-order.md).
+: These modules are used exclusively in the darkroom view, and each performs a layer of pixel processing operations on your image. Together they form the [pixelpipe](../darkroom/processing-modules-and-pixelpipe/the-pixelpipe-and-module-order.md).
 
 [utility modules](./utility-modules/_index.md)
-: These modules may be used in any darktable view. They perform other ancillary functions related to managing the image metadata and tags, editing history, pixel pipeline order, snapshots and duplicates, image export and so on.
+: These modules may be used in any darktable view. They are not directly involved in processing the pixels of your image; instead they perform other ancillary functions related to managing the image metadata and tags, editing history, modifying overall pixel pipeline order, snapshots and duplicates, image export and so on.
 
 The two types of modules have a few aspects in common, as described below.
 


### PR DESCRIPTION
After discussion with Aurélien on IRC, try to use analogy of "layers" to better explain processing modules, and try to make the distinction against utility modules clearer.