### PR TITLE
Style shortcuts

### DIFF
--- a/content/module-reference/utility-modules/darkroom/history-stack.md
+++ b/content/module-reference/utility-modules/darkroom/history-stack.md
@@ -28,4 +28,5 @@ Clicking the "reset parameters" button in the module header discards the entire 
 
 The button to the right of the "compress history stack" button allows you to create a new style from the history stack of the current image, which can then be applied to other images. Use the first line of the popup dialog window to name your style and the second to add a searchable description. You will be prompted to choose which of the current history stack modules to include in the style.
 
-Once created, styles can be managed and applied to other images with the lighttable's [styles](../lighttable/styles.md) module. 
+Once created, styles can be managed and applied to other images with the lighttable's [styles](../lighttable/styles.md) module.  You can also assign shortcut keys to your styles (see [shortcuts](../../../preference-settings/shortcuts.md) in preferences) and apply the associated style to all selected images by pressing the shortcut key whenever you are in the lighttable or darkroom view.
+

--- a/content/module-reference/utility-modules/lighttable/styles.md
+++ b/content/module-reference/utility-modules/lighttable/styles.md
@@ -12,7 +12,7 @@ Styles can either be created within this panel or in the [history stack](../dark
 
 A list of all available styles is displayed at the top of the module. A search field above the list allows you to locate a style by name or description. This module also allows styles to be edited and deleted.
 
-Double-click on a style name to apply that style to all selected images. 
+Double-click on a style name to apply that style to all selected images.  A style may also be applied to all selected images by pressing a shortcut key assigned to it (see [shortcuts](../../../preferences-settings/shortcuts.md)) while in either lighttable or darkroom view.
 
 # module controls
 


### PR DESCRIPTION
Point out that styles can also be assigned to shortcut keys.

There should be mention of this in shortcuts.md, but that's a bigger insertion than the equivalent mention for presets was.  Probably a new subsection to explain that global -> styles gives a list of currently-defined styles for assignment to shortcut keys.
